### PR TITLE
Update property manager for 0.9.0 support

### DIFF
--- a/modules/custompropertymanager.js
+++ b/modules/custompropertymanager.js
@@ -39,7 +39,7 @@ class CLCustomPropertyManager {
         if (!pointSource._source) {
             return; // Source is not cached yet, return
         }
-        var customProperties = pointSource.object.getFlag("CommunityLighting", "customProperties");
+        var customProperties = pointSource.object.document.getFlag("CommunityLighting", "customProperties");
 
         // Remove any customProperties from the current lightAnimation object
         Object.keys(pointSource.object.data._source.lightAnimation).forEach(key => {


### PR DESCRIPTION
Fixes the following runtime warning:

You are calling PlaceableObject#getFlag which has been deprecated in favor of Document#getFlag. Support will be removed in 0.9.0